### PR TITLE
fix(db): remove client-side timestamp generation

### DIFF
--- a/src/lib/supabase/queries.ts
+++ b/src/lib/supabase/queries.ts
@@ -41,7 +41,6 @@ export async function createEntry(entry: NewEntry): Promise<Entry> {
         user_id: user.id,
         title: entry.title,
         content: entry.content,
-        created_at: new Date().toISOString()
       }
     ])
     .select()


### PR DESCRIPTION
Closes #3. Flyttar ansvaret för att sätta 'created_at' från klienten till databasen via DEFAULT now().