### PR TITLE
chore(docker): update to multi-stage build using pnpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,66 +1,41 @@
 
-# När Docker bygger en image används .dockerignore för att undvika att kopiera in känsliga filer (som .env) in i imagen.
-# Next.js behöver NEXT_PUBLIC_* variablerna vid build-time för att baka in dem i JavaScript-bundlen som skickas till webbläsaren.
-
-# Utan tillgång till .env-filen i Docker-containern under npm run build finns inga värden att baka in. 
-
-# Med en multi-stage build (lösningen nedan) passerar vi värdena som build-arguments (ARG) istället för att kopiera in .env-filen. Värdena används i build-staget för att
-# kompilera appen, men det slutgiltiga production-staget innehåller bara den färdiga .next-mappen - inte build-argumenten.
-
-# När ni bvygger sen behöver ni skicka in build-argarna som ni får från supabase.
-# Detta finns då tillgängligt i build-processen och bakas ju sen in i koden via next build.
-# Men eftersom vi gör en multi-stage build så finns de inte med i production stage.
-# Detta är helt ok eftersom supabase nycklar är byggda för att kunna användas i klienten (så länge man har RLS-policies)
-# Men gör inte såhär för några nycklar som ska vara hemliga!
-#docker build \
-#--build-arg NEXT_PUBLIC_SUPABASE_URL=<eran-supabase-url> \
-#--build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY=<eran-anon-key> \
-#-t dagboks-appen .
-
-# Build stage
+# --- Steg 1: Bygg-miljö ---
 FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# Kopiera package files
-COPY package*.json ./
+# Installera pnpm globalt
+RUN npm install -g pnpm
 
-# Installera dependencies
-RUN npm install
+# Kopiera package.json och pnpm-lock.yaml
+COPY package.json pnpm-lock.yaml ./
 
-# Kopiera all kod
+# Installera produktionsberoenden
+RUN pnpm install --prod
+
+# Kopiera resten av koden
 COPY . .
 
-# Deklarera build arguments för Supabase
+# Bygg Next.js-appen med build-argument
 ARG NEXT_PUBLIC_SUPABASE_URL
 ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ENV NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL}
+ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+RUN pnpm build
 
-# Sätt dem som miljövariabler för build-processen
-ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
-ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
-
-# Bygg applikationen
-RUN npm run build
-
-# Production stage
+# --- Steg 2: Produktions-miljö ---
 FROM node:20-alpine AS runner
 
 WORKDIR /app
 
-ENV NODE_ENV=production
-
-# Kopiera package files och installera endast production dependencies
-COPY package*.json ./
-RUN npm ci --only=production
-
-# Kopiera byggda filer från builder stage
+# Kopiera byggda filer och nödvändiga paket från "builder"
 COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/public ./public
 
-# Exponera port
 EXPOSE 3000
 
-# Starta applikationen
-CMD ["npm", "start"]
-
+# Starta appen med pnpm
+CMD ["pnpm", "start"]
 


### PR DESCRIPTION
Closes #4. Uppdaterar Dockerfile till en modern multi-stage build som använder pnpm för att vara konsekvent med resten av projektet. Detta resulterar i en mindre och säkrare produktions-image.