### PR TITLE
ci: Add Docker build and push job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,62 +1,79 @@
 name: CI
 
-# 🔹 När workflow ska köras
 on:
   push:
     branches:
-      - develop
-      - main
-      - feature/*
+      - '**'
+    tags:
+      - 'v*.*.*'
   pull_request:
     branches:
-      - develop
       - main
+      - develop
 
 jobs:
   build:
-    name: Lint, Test & Build
     runs-on: ubuntu-latest
-
     steps:
-      # 1️⃣ Hämta koden från GitHub
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
 
-      # 2️⃣ Installera pnpm CLI
-      - name: Install pnpm
+      - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 9
-          run_install: false
+          version: 8
 
-      # 3️⃣ Installera Node.js (utan cache-rad)
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: '20'
+          cache: 'pnpm'
 
-      # 4️⃣ Installera beroenden
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
-        # 🔹 Först försöker vi strikt installation, annars fallback utan freeze
+        run: pnpm install
 
-      # 5️⃣ Kontrollera kodstil (Lint)
-      - name: Lint code
+      - name: Lint
         run: pnpm lint
 
-      # 6️⃣ Kör tester (Vitest)
       - name: Run tests
         run: pnpm test
 
-      # 7️⃣ Bygg Next.js
-      - name: Build Next.js
+      - name: Build
         run: pnpm build
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
 
-      # 8️⃣ Visa Node och pnpm-version för felsäkerhet (valfritt)
-      - name: Check Node & pnpm version
-        run: |
-          node -v
-          pnpm -v
+  build-and-push-docker:
+    # Kör bara detta jobb om en tagg har push-ats
+    if: startsWith(github.ref, 'refs/tags/')
+    # Kör inte detta jobb om 'build'-jobbet misslyckas
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/cloud-examinerande-uppgift-2-grupp8
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Adds a new job to the CI pipeline that builds and pushes a Docker image to Docker Hub whenever a new version tag (e.g., v1.0.0) is pushed.