### PR TITLE
fix(docker): Install devDependencies during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN npm install -g pnpm
 COPY package.json pnpm-lock.yaml ./
 
 # Installera produktionsberoenden
-RUN pnpm install --prod
+RUN pnpm install
 
 # Kopiera resten av koden
 COPY . .


### PR DESCRIPTION
The build process requires TypeScript, which is a devDependency. This commit changes 'pnpm install --prod' to 'pnpm install' in the Dockerfile to ensure all necessary packages are available during the build stage.